### PR TITLE
Migrate run_command function in daemon.py

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 exclude = .??*, venv
-ignore = E203, E266, E501
+extend-ignore = E203, E266, E501
 max-line-length = 88
 max-complexity = 18
 select = B,C,E,F,W,T4,B9

--- a/epidose/common/daemon.py
+++ b/epidose/common/daemon.py
@@ -21,6 +21,7 @@ __license__ = "Apache 2.0"
 
 import logging
 import sys
+import subprocess
 
 
 class Daemon(object):
@@ -59,3 +60,20 @@ class Daemon(object):
     def get_args(self):
         """Return the parsed arguments passed to the constructor."""
         return self.args
+
+    def run_command(self, cmd):
+        """Run (or simulate the running of) the specified command.
+        Log the command to be run.
+        Do not run the command if dry_run is set.
+        Log operating system and command errors.
+        """
+        self.logger.debug(" ".join(cmd))
+
+        try:
+            result = subprocess.run(cmd, check=True, capture_output=True)
+        except subprocess.CalledProcessError as e:
+            self.logger.error(f"{cmd[0]} failed with code {e.returncode}: {e.stderr}")
+        except OSError as e:
+            self.logger.error(f"Failed to run {cmd[0]}: {e.strerror}")
+        finally:
+            return result

--- a/tests/test_run_commnad.py
+++ b/tests/test_run_commnad.py
@@ -1,0 +1,37 @@
+__copyright__ = """
+    Copyright 2020 Stefanos Georgiou
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+__license__ = "Apache 2.0"
+
+import types
+from epidose.common.daemon import Daemon
+
+
+def test_run_command():
+    args = types.SimpleNamespace()
+    args.debug = True
+    args.verbose = True
+
+    daemon = Daemon("test_run_command", args)
+    global logger
+    logger = daemon.get_logger()
+
+    result = daemon.run_command(["true"])
+    assert result.returncode == 0
+
+    try:
+        result = daemon.run_command(["false"])
+    except Exception as e:
+        logger.debug(f"{e}")


### PR DESCRIPTION
Had to change the ignore to extend-ignore because the flake8 was not ignoring the
':' after space and was causing a conflict with black pre-commit hook:

black....................................................................Failed
- hook id: black
- files were modified by this hook

reformatted /home/epidose/epidose/epidose/device/beacon_tx_unlinkable_d.py
All done!
1 file reformatted, 4 files left unchanged.

flake8...................................................................Failed
- hook id: flake8
- exit code: 1

epidose/device/beacon_tx_unlinkable_d.py:90:25: E203 whitespace before ':'
epidose/device/beacon_tx_unlinkable_d.py:95:27: E203 whitespace before ':'
epidose/device/beacon_tx_unlinkable_d.py:130:33: E203 whitespace before ':'

Test shell scripts with shellcheck...................(no files to check)Skipped