### PR TITLE
Fix network connect in wps_scanner

### DIFF
--- a/epidose/device/supervisord.conf
+++ b/epidose/device/supervisord.conf
@@ -27,7 +27,7 @@ stderr_logfile=/var/log/%(program_name)s ; stderr log path, NONE for none; defau
 stderr_logfile_maxbytes=1MB    ; max # logfile bytes b4 rotation (default 50MB)
 
 [program:update_filter]
-command=/opt/venvs/epidose/bin/update_filter_d.sh -i -v -d https://istlab.dmst.aueb.gr/epidose/
+command=/opt/venvs/epidose/bin/update_filter_d.sh -i -v https://istlab.dmst.aueb.gr/epidose/
 directory=/                    ; directory to cwd to before exec (def no cwd)
 priority=50                    ; the relative start priority (default 999)
 startsecs=5                    ; # of secs prog must stay up to be running (def. 1)
@@ -41,7 +41,7 @@ stderr_logfile=/var/log/%(program_name)s ; stderr log path, NONE for none; defau
 stderr_logfile_maxbytes=1MB    ; max # logfile bytes b4 rotation (default 50MB)
 
 [program:upload_seeds]
-command=/opt/venvs/epidose/bin/upload_seeds_d.sh -i -v -d https://istlab.dmst.aueb.gr/epidose/
+command=/opt/venvs/epidose/bin/upload_seeds_d.sh -i -v https://istlab.dmst.aueb.gr/epidose/
 directory=/                    ; directory to cwd to before exec (def no cwd)
 priority=70                    ; the relative start priority (default 999)
 startsecs=5                    ; # of secs prog must stay up to be running (def. 1)
@@ -69,7 +69,7 @@ stderr_logfile=/var/log/%(program_name)s ; stderr log path, NONE for none; defau
 stderr_logfile_maxbytes=1MB    ; max # logfile bytes b4 rotation (default 50MB)
 
 [program:wps_scanner]
-command=/opt/venvs/epidose/bin/wps_scanner_d.sh -i -v -d https://istlab.dmst.aueb.gr/epidose/
+command=/opt/venvs/epidose/bin/wps_scanner_d.sh -i -v https://istlab.dmst.aueb.gr/epidose/
 directory=/                    ; directory to cwd to before exec (def no cwd)
 priority=50                    ; the relative start priority (default 999)
 startsecs=5                    ; # of secs prog must stay up to be running (def. 1)


### PR DESCRIPTION
Here is the wps_scanner log:

```
2020-12-22 22:40:24,405: Waiting for WiFi button press; press ^C and button to abort
2020-12-22 22:40:41,072: WiFi button pressed
2020-12-22 22:40:41 Acquiring WiFi
2020-12-22 22:40:41 Turn on WiFi
2020-12-22 22:40:41 Temporary stop beacon transmissions
2020-12-22 22:40:59 Acquired WiFi
2020-12-22 22:40:59 Trying to connect to PrimeTel-592
RTNETLINK answers: File exists
2020-12-22 22:41:00 Successfully connected to network
2020-12-22 22:41:01,518: Turn green LED on
2020-12-22 22:41:01 Obtained network connection
2020-12-22 22:41:01 Killing update_filter_d's sleep process
2020-12-22 22:41:40,855: No contact match
2020-12-22 22:41:41 Releasing WiFi
2020-12-22 22:41:41 Released WiFi
2020-12-22 22:41:42,036: Waiting for WiFi button press; press ^C and button to abort
```

I was unable to connect to my parent's WiFi to change the name to Epidose.
To update your current image execute the following steps:

* Mount your microSD card in the PC and enable the WiFi by commenting the `ip link set wlan0 down` from the media/dspinellis/rootfs/etc/rc.local (I guess this is your path for the microSD)
* Insert back your microSD to the epidose and restart your device
* Then pull the latest changes, after you merged this commit, after entering the epidose directory (found in /home/epidose/)
* Build again `make fast-install`
* Uncomment the line `ip link set wlan0 down` from the /etc/rc.local
* sudo reboot
* Now you are ready to test if the epidose connects to the epidose network
* After pressing the Wifi button you need to wait approximately 15 seconds (as defined in the epidose/device/util.sh) in order to obtain network connection (you may also see the green LED blink for two seconds)
* You can ssh or ping to the device IP address to verify that your device has a network connection



