### PR TITLE
Add mechanism to update until the latest Ansible tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,14 @@ restart selective daemons by running *supervisorctl* with appropriate
 arguments.
 
 
+A mechanism also exist to update the device configurations by using the Ansbile script.
+For each new update,
+add the necessary changes in the `epidose/device/install_and_configure.yml`
+with a tag, for example `update_2`.
+To apply the update on the device add the following
+in the `update.sh` file: `echo update_2 > /var/lib/epidose/latest_update`
+This will ensure that the device is updated up unitl the `update_2` tag.
+
 
 ### Update server's URL
 To update the server's URL where the epidose device


### PR DESCRIPTION
This is needed if we want to update configurations on the device.
For each new update added in the Ansible script, we create a new tag (i.e., update_2) and a function (`update_ansbile`) inside the `epidose/device/utils.sh` is responsible to update until the latest tag.
To update up to a specific tag, a user has to add the corresponding tag in the `update.sh` file.
For example, `echo update_3 >> /var/lib/epidose/latest_update` and the update function will execute all tags from the current until the latest.
I have also updated the README file about this.