### PR TITLE
Automate certificate creation for ha-server deployment script

### DIFF
--- a/epidose/back_end/deploy.yml
+++ b/epidose/back_end/deploy.yml
@@ -10,17 +10,20 @@
       apt:
         name: ['libbluetooth-dev', 'libglib2.0-dev', 'python3-dev',
         'python3-setuptools', 'shellcheck', 'sqlite3', 'virtualenv',
-        'dh-virtualenv', 'debhelper', 'supervisor', 'nginx']
+        'dh-virtualenv', 'debhelper', 'supervisor', 'nginx',
+        'certbot', 'python3-certbot-nginx']
 
     - name: install python modules
       become: yes
       become_user: root
       shell: |
         cd ../../
+        sed -i 's/armhf/amd64/g' Makefile
         virtualenv venv -p /usr/bin/python3
         . venv/bin/activate
         pip3 install -e ".[dev,test,deploy]"
         make package
+        service supervisor start
         make install
       register: modules_installation
 
@@ -44,21 +47,22 @@
     - debug:
          msg: "{{ gunicorn_debug.stdout_lines|list }}"
 
-    - name: remove default nginx site
+    - name: create nginx config file for ha-server
       become: yes
       become_user: root
       file:
-        path: /etc/nginx/sites-available/ha-server.conf
+        path: /etc/nginx/conf.d/{{ server_name }}.conf
         state: touch
         owner: root
         group: root
         mode: 0644
 
-    - name: add ha-server configurations
+    - name: add nginx configurations
+      tags: nginx
       become: yes
       become_user: root
       blockinfile: |
-        dest=/etc/nginx/sites-available/ha-server.conf
+        dest=/etc/nginx/conf.d/{{ server_name }}.conf
         content='server {
                     listen 80;
                     server_name {{ server_name }};
@@ -66,21 +70,17 @@
                     access_log /var/log/nginx_access.log;
                     error_log /var/log/nginx_error.log;
 
+                    if ($scheme != "https") { 
+                      return 301 https://{{ server_name }}$request_uri;
+                    }
+
                     location / {
                       proxy_set_header X-Forward-For $proxy_add_x_forwarded_for;
                       proxy_set_header Host $http_host;
                       proxy_redirect off;
-                      proxy_pass http://127.0.0.1:5010;
+                      proxy_pass http://185.70.186.134:5010;
                     }
                   }'
-
-    - name: create symbolic link of ha-server.conf
-      become: yes
-      become_user: root
-      file:
-        src: /etc/nginx/sites-available/ha-server.conf
-        dest: /etc/nginx/sites-enabled/ha-server.conf
-        state: link
 
     - name: enable nginx server
       become: yes
@@ -95,3 +95,16 @@
       systemd:
         name: nginx
         state: restarted
+
+    - name: obtain certificate
+      become: yes
+      become_user: root
+      shell: certbot --nginx --non-interactive -d {{ server_name }} --agree-tos --email stefanos1316@gmail.com --email dds@aueb.gr
+
+    - name: add cron entry to renew cert every 12 hours
+      become: yes
+      become_user: root
+      cron:
+        name: update cert every 12 hours
+        minutes: "1, 31"
+        job: "/usr/bin/certbot renew --quiet && service nginx reload"


### PR DESCRIPTION
Have updated the script in order to automate the certificate creation and update.
I have executed the script on the remote host (185.70.186.134) and tested the following:

`$ curl -X GET http://epidose.ellak.gr/filter`

<html>
<head>301 Moved Permanently</head>
<body bgcolor="white">
<center>301 Moved Permanently</center>
<center>nginx/1.14.2</center>
</body>
</html><br \>

`$ curl -X GET https://epidose.ellak.gr/filter <br \>
Hi Stefanos, this works!`

Let me know if this is fine or changes are required.