### PR TITLE
Set server URL to EOSC VM

### DIFF
--- a/epidose/device/supervisord.conf
+++ b/epidose/device/supervisord.conf
@@ -27,7 +27,7 @@ stderr_logfile=/var/log/%(program_name)s ; stderr log path, NONE for none; defau
 stderr_logfile_maxbytes=1MB    ; max # logfile bytes b4 rotation (default 50MB)
 
 [program:update_filter]
-command=/opt/venvs/epidose/bin/update_filter_d.sh -i -v https://istlab.dmst.aueb.gr/epidose/
+command=/opt/venvs/epidose/bin/update_filter_d.sh -i -v https://epidose.ellak.gr/
 directory=/                    ; directory to cwd to before exec (def no cwd)
 priority=50                    ; the relative start priority (default 999)
 startsecs=5                    ; # of secs prog must stay up to be running (def. 1)
@@ -41,7 +41,7 @@ stderr_logfile=/var/log/%(program_name)s ; stderr log path, NONE for none; defau
 stderr_logfile_maxbytes=1MB    ; max # logfile bytes b4 rotation (default 50MB)
 
 [program:upload_seeds]
-command=/opt/venvs/epidose/bin/upload_seeds_d.sh -i -v https://istlab.dmst.aueb.gr/epidose/
+command=/opt/venvs/epidose/bin/upload_seeds_d.sh -i -v https://epidose.ellak.gr/
 directory=/                    ; directory to cwd to before exec (def no cwd)
 priority=70                    ; the relative start priority (default 999)
 startsecs=5                    ; # of secs prog must stay up to be running (def. 1)
@@ -69,7 +69,7 @@ stderr_logfile=/var/log/%(program_name)s ; stderr log path, NONE for none; defau
 stderr_logfile_maxbytes=1MB    ; max # logfile bytes b4 rotation (default 50MB)
 
 [program:wps_scanner]
-command=/opt/venvs/epidose/bin/wps_scanner_d.sh -i -v https://istlab.dmst.aueb.gr/epidose/
+command=/opt/venvs/epidose/bin/wps_scanner_d.sh -i -v https://epidose.ellak.gr/
 directory=/                    ; directory to cwd to before exec (def no cwd)
 priority=50                    ; the relative start priority (default 999)
 startsecs=5                    ; # of secs prog must stay up to be running (def. 1)


### PR DESCRIPTION
Changed the server URL where the devices are fetching the `update.sh` and `filter.sh`.
 Now, the devices will use the `https://epidose.ellak.gr`.
Here is the output from the current test:

```
2021-04-20 09:26:47 Killed during sleep; obtaining a new filter
2021-04-20 09:26:47 Obtaining new filter from https://epidose.ellak.gr/
2021-04-20 09:26:47 Acquiring WiFi
2021-04-20 09:26:47 Turn on WiFi
2021-04-20 09:26:47 Temporary stop beacon transmissions
2021-04-20 09:26:49 Acquired WiFi
2021-04-20 09:26:49 Checking for updates
2021-04-20 09:26:50 New update script obtained: 188 bytes
2021-04-20 09:27:51 New filter obtained: 188 bytes 
``` 

As said, the server will generate a new filter every six hours by invoking the following cronjob:
```
0 */6 * * * /home/sgeorgiou/epidose/venv/bin/python /home/sgeorgiou/epidose/epidose/back_end/create_filter.py -v -d /var/lib/epidose/filter.bin
```

I have used the /home/sgeorgiou since this account was created for me by ELLAK.
If you like to, I can create another root account named `epidose` that we share between us.

Also, I will issue another PR to generate the above cronjob through the deploy.yml script of the back_end.